### PR TITLE
Remove std:: to use OOP-AD overloaded functions

### DIFF
--- a/sophus/so2.hpp
+++ b/sophus/so2.hpp
@@ -204,7 +204,7 @@ public:
   inline
   void normalize() {
     Scalar length =
-        std::sqrt(unit_complex().x()*unit_complex().x()
+        sqrt(unit_complex().x()*unit_complex().x()
              + unit_complex().y()*unit_complex().y());
     if(length < SophusConstants<Scalar>::epsilon()) {
       throw SophusException("Complex number is (near) zero!");
@@ -320,7 +320,7 @@ public:
    */
   inline static
   const SO2Group<Scalar> exp(const Tangent & theta) {
-    return SO2Group<Scalar>(std::cos(theta), std::sin(theta));
+    return SO2Group<Scalar>(cos(theta), sin(theta));
   }
 
   /**


### PR DESCRIPTION
The use of std:: on basic math functions prevents the use of OOP AD (Automatic Differentiation) with Sophus.

This PR is incomplete as it only covers SO(2) and SE(2), and it's still not clear if it's a good idea to remove std:: from abs, since for this specific function it's needed to avoid using the int overloaded version.

However, if these changes are welcomed, I can apply them to all the Lie Groups, and look for a solution for std::abs (if I actually have to change it).

I'm testing with ceres solver Jet class for AD.

Also, let me know if you prefer that I send this PR upstream, instead of to your fork, but I think yours is the version used to generate debians for ROS indigo, right?
