### PR TITLE
Relocatable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,15 +29,6 @@ list( APPEND CMAKE_MODULE_PATH "${CMAKE_ROOT}/Modules" )
 find_package( Eigen3 REQUIRED )
 
 ################################################################################
-# Create variables used for exporting in sophusConfig.cmake
-set( sophus_LIBRARIES "" )
-set( sophus_INCLUDE_DIRS ${CMAKE_INSTALL_PREFIX}/include ${EIGEN3_INCLUDE_DIR} )
-# We may not actually need these, so leaving them out for now.
-# set( sophus_VERSION "...get from package.xml")
-# set( sophus_DEFINITIONS "-Wall -Werror -Wno-unused-variable
-#                   -Wno-unused-but-set-variable -Wno-unknown-pragmas")
-
-################################################################################
 # Package
 
 include_directories( ${EIGEN3_INCLUDE_DIR} )

--- a/sophusConfig.cmake.in
+++ b/sophusConfig.cmake.in
@@ -10,11 +10,8 @@
 
 # http://www.cmake.org/Wiki/CMake/Tutorials/How_to_create_a_ProjectConfig.cmake_file
 
-# This is ideal so that it can be made relocatable, but we'd need to
-# handle the eigen in a relocatable way as well.
-#get_filename_component(sophus_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-
-set( sophus_INCLUDE_DIRS  "@sophus_INCLUDE_DIRS@" )
+# Specify include path relative to this find module, so that the installed tree can be relocated.
+set( sophus_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../include;@EIGEN3_INCLUDE_DIR@")
 
 # Not using yet - see CMakeLists.txt
 # set( sophus_VERSION "")


### PR DESCRIPTION
This PR makes the sophus installation relocatable.

In a blank, unchained workspace (unset CMAKE_PREFIX_PATH):

```
rosinstall_generator --rosdistro indigo --deps ecl_geometry --tar > ecl.rosinstall
rosinstall ecl.rosinstall src
catkin config --install --install-space /opt/fun
DESTDIR=$(pwd)/tmp catkin build ecl_geometry
```

Output without this change is:

```
.
.
.
Starting  >>> ecl_geometry               
________________________________________________________________________________________________________________________________________________________________________________________________________
Errors     << ecl_geometry:cmake /home/mpurvis/ecl_ws/build/_logs/ecl_geometry/build.cmake.000.log
CMake Error at /home/mpurvis/ecl_ws/src/ecl_core/ecl_geometry//home/mpurvis/ecl_ws/devel/share/ecl_linear_algebra/cmake/ecl_linear_algebraConfig.cmake:106 (message):
  Project 'ecl_linear_algebra' specifies '/opt/fun/include' as an include
  dir, which is not found.  It does neither exist as an absolute directory
  nor in
  '/home/mpurvis/ecl_ws/src/ecl_core/ecl_linear_algebra//opt/fun/include'.
  Ask the maintainer 'Daniel Stonier <d.stonier@gmail.com>' to fix it.
Call Stack (most recent call first):
  /home/mpurvis/ecl_ws/tmp/opt/fun/share/catkin/cmake/catkinConfig.cmake:75 (find_package)
  CMakeLists.txt:12 (find_package)


cd /home/mpurvis/ecl_ws/build/ecl_geometry; catkin build --get-env ecl_geometry | catkin env -si  /usr/bin/cmake /home/mpurvis/ecl_ws/src/ecl_core/ecl_geometry --no-warn-unused-cli -DCATKIN_DEVEL_PREFI
X=/home/mpurvis/ecl_ws/devel -DCMAKE_INSTALL_PREFIX=/opt/fun; cd -
........................................................................................................................................................................................................
Failed     << ecl_geometry:cmake          [ Exited with code 1 ]
Failed    <<< ecl_geometry                [ 0.9 seconds ]
```

With this change, the workspace builds correctly.
